### PR TITLE
Add build status badges pointing to this repo instead of legacy one

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ An NVMe Device Simulation Library.
 
 This is a WIP simulation of the protocol-layer of an NVMe Memory Device. The goal is to be able to send NVMe commands down and get full protocol responses. The simulation includes a register level with basic PCIe Controller Registers and simplified Doorbell Registers. It is really cool!
 
-Linux Build Status: [![Build Status](https://travis-ci.org/csm10495/cNVMe.svg?branch=linux-testing)](https://travis-ci.org/csm10495/cNVMe)
+Linux Build Status: [![Build Status](https://travis-ci.org/intel/cNVMe.svg?branch=master)](https://travis-ci.org/intel/cNVMe)
 
-Windows Build Status: [![Build status](https://ci.appveyor.com/api/projects/status/7fovagftoeoahgup/branch/master?svg=true)](https://ci.appveyor.com/project/csm10495/cnvme/branch/master)
+Windows Build Status: [![Build status](https://ci.appveyor.com/api/projects/status/svfanibbsfm94d4f/branch/master?svg=true)](https://ci.appveyor.com/project/csm10495/cnvme-v65dl/branch/master)
 
 The original (and now legacy) repository for this project can be found here, for history purposes: [csm10495/cNVMe](https://github.com/csm10495/cNVMe)
 


### PR DESCRIPTION
This should be able to fix #3 